### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/liangzhu0794/cea1d640-c075-4cfc-99e2-5b3c2c8daf1d/72db2467-2871-474c-a5b9-f6200e3f646a/_apis/work/boardbadge/35f0d4f1-feca-43d7-a49c-1fe515de46ad)](https://dev.azure.com/liangzhu0794/cea1d640-c075-4cfc-99e2-5b3c2c8daf1d/_boards/board/t/72db2467-2871-474c-a5b9-f6200e3f646a/Microsoft.RequirementCategory)
 # hookmax
 test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/liangzhu0794/cea1d640-c075-4cfc-99e2-5b3c2c8daf1d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.